### PR TITLE
Update instructions for TurrisOS 6.0

### DIFF
--- a/lighttpd_custom.conf
+++ b/lighttpd_custom.conf
@@ -1,42 +1,30 @@
+# Modern configuration from
+# https://ssl-config.mozilla.org/
+# Last verified: 22 October 2022
+
 server.port  = 443
-ssl.engine   = "enable"
-setenv.add-environment = (
-    "HTTPS" => "on"
-)
 
-# pemfile is cert, privkey is private key, ca-file is the intermediate chain in one file
-ssl.pemfile = "/etc/lighttpd/certs/domain.example.com/domain.example.com.cer"
-ssl.privkey = "/etc/lighttpd/certs/domain.example.com/domain.example.com.key"
-ssl.ca-file = "/etc/lighttpd/certs/domain.example.com/fullchain.cer"
+# Port 80 is disabled, but this doesn't hurt...
+$HTTP["scheme"] == "http" {
+    url.redirect = ("" => "https://${url.authority}${url.path}${qsa}")
+}
 
-# modern configuration
-ssl.openssl.ssl-conf-cmd  = ("Protocol" => "ALL, -SSLv2, -SSLv3, -TLSv1, -TLSv1.1, -TLSv1.2")
-ssl.cipher-list           = ""
-ssl.honor-cipher-order    = "disable"
-
-# HTTP Strict Transport Security (63072000 seconds)
-setenv.add-response-header  = (
-    "Strict-Transport-Security" => "max-age=63072000"
-)
-
-$SERVER["socket"] == "[::]:443" {
-    ssl.engine   = "enable"
+$HTTP["scheme"] == "https" {
+    # HTTP Strict Transport Security (63072000 seconds)
+    setenv.add-response-header = (
+        "Strict-Transport-Security" => "max-age=63072000"
+    )
     setenv.add-environment = (
         "HTTPS" => "on"
     )
-
-    # pemfile is cert, privkey is private key, ca-file is the intermediate chain in one file
-    ssl.pemfile = "/etc/lighttpd/certs/domain.example.com/domain.example.com.cer"
-    ssl.privkey = "/etc/lighttpd/certs/domain.example.com/domain.example.com.key"
-    ssl.ca-file = "/etc/lighttpd/certs/domain.example.com/fullchain.cer"
-
-    # modern configuration
-    ssl.openssl.ssl-conf-cmd = ("Protocol" => "ALL, -SSLv2, -SSLv3, -TLSv1, -TLSv1.1, -TLSv1.2")
-    ssl.cipher-list           = ""
-    ssl.honor-cipher-order    = "disable"
-
-    # HTTP Strict Transport Security (63072000 seconds)
-    setenv.add-response-header  = (
-        "Strict-Transport-Security" => "max-age=63072000"
-    )
 }
+
+# lighttpd 1.4.56 and later will inherit ssl.* from the global scope if
+# $SERVER["socket"] contains ssl.engine = "enable" and no other ssl.* options
+# (to avoid having to repeat ssl.* directives in both ":443" and "[::]:443")
+$SERVER["socket"] ==     ":443" { ssl.engine = "enable" }
+$SERVER["socket"] == "[::]:443" { ssl.engine = "enable" }
+ssl.pemfile = "/etc/lighttpd/certs/domain.example.com/domain.example.com.cer"
+ssl.privkey = "/etc/lighttpd/certs/domain.example.com/domain.example.com.key"
+ssl.openssl.ssl-conf-cmd = ("MinProtocol" => "TLSv1.3")
+ssl.openssl.ssl-conf-cmd += ("Options" => "-ServerPreference")

--- a/updater_custom.lua
+++ b/updater_custom.lua
@@ -1,0 +1,2 @@
+Uninstall("lighttpd-https-cert", { priority = 60 })
+


### PR DESCRIPTION
TurrisOS 6.0 is now standard even for the HBS (stable) branch.

It uses lighttpd 1.4.67, and has a different structure for the lighttpd configuration below /etc/lighttpd/conf.d.

The more modern version of lighttpd can use a much simpler SSL configuration, and the current version of acme.sh uses ZeroSSL per default, so some changes are needed to use letsencrypt.